### PR TITLE
fix: store floating nodes in appropriate list

### DIFF
--- a/i3ipc.py
+++ b/i3ipc.py
@@ -423,7 +423,7 @@ class Con(object):
 
         self.floating_nodes = []
         for n in data['floating_nodes']:
-            self.nodes.append(Con(n, self, conn))
+            self.floating_nodes.append(Con(n, self, conn))
 
         self.window_class = None
         self.window_instance = None


### PR DESCRIPTION
nodes list contain non float nodes
floating_nodes contain floating nodes respectively
to get all nodes use descendants method