### PR TITLE
Add 'scratchpad_state' to properties

### DIFF
--- a/i3ipc.py
+++ b/i3ipc.py
@@ -396,7 +396,7 @@ class Con(object):
         ipc_properties = ['border', 'current_border_width', 'focused',
                           'fullscreen_mode', 'id', 'layout', 'mark', 'name',
                           'orientation', 'percent', 'type', 'urgent', 'window',
-                          'num']
+                          'num', 'scratchpad_state']
         for attr in ipc_properties:
             if attr in data:
                 setattr(self, attr, data[attr])


### PR DESCRIPTION
Need this for a scratchpad segment in powerline/powerline#1542. The key is required to identify currently-visible scratchpad windows as such (they are indistinguishable from floating windows otherwise)