### PR TITLE
Remove interactions with Xlib and python3-xlib dependency

### DIFF
--- a/i3ipc.py
+++ b/i3ipc.py
@@ -6,7 +6,6 @@ import socket
 import os
 import re
 from enum import Enum
-from Xlib import display
 
 
 class MessageType(Enum):
@@ -173,14 +172,7 @@ class Connection(object):
             socket_path = os.environ.get("I3SOCK")
 
         if not socket_path:
-            d = display.Display()
-            r = d.screen().root
-            data = r.get_property(d.get_atom('I3_SOCKET_PATH'),
-                                  d.get_atom('UTF8_STRING'), 0, 9999)
-
-            if not data.value:
-                raise Exception('could not get i3 socket path')
-            socket_path = data.value
+            raise Exception('could not get i3 socket path')
 
         self._pubsub = _PubSub(self)
         self.props = _PropsObject(self)

--- a/i3ipc.py
+++ b/i3ipc.py
@@ -5,6 +5,7 @@ import json
 import socket
 import os
 import re
+import subprocess
 from enum import Enum
 
 
@@ -172,7 +173,12 @@ class Connection(object):
             socket_path = os.environ.get("I3SOCK")
 
         if not socket_path:
-            raise Exception('could not get i3 socket path')
+            try:
+                socket_path = subprocess.check_output(
+                    ['i3', '--get-socketpath'],
+                    close_fds=True, universal_newlines=True)
+            except:
+                raise Exception('Failed to retrieve the i3 IPC socket path')
 
         self._pubsub = _PubSub(self)
         self.props = _PropsObject(self)

--- a/i3ipc.py
+++ b/i3ipc.py
@@ -32,7 +32,7 @@ class Event(object):
 class _ReplyType(dict):
 
     def __getattr__(self, name):
-            return self[name]
+        return self[name]
 
     def __setattr__(self, name, value):
         self[name] = value

--- a/i3ipc.py
+++ b/i3ipc.py
@@ -292,10 +292,9 @@ class Connection(object):
 
     def on(self, detailed_event, handler):
         event = detailed_event.replace('-', '_')
-        detail = ''
 
         if detailed_event.count('::') > 0:
-            [event, detail] = detailed_event.split('::')
+            [event, __] = detailed_event.split('::')
 
         # special case: ipc-shutdown is not in the protocol
         if event == 'ipc-shutdown':

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 readme_path = path.join(path.abspath(path.dirname(__file__)), 'README.rst')
 long_description = open(readme_path).read()
 
-install_requires = ['python3-xlib', 'enum-compat']
+install_requires = ['enum-compat']
 
 setup(
     name='i3ipc',


### PR DESCRIPTION
The state of Xlib/XCB Python bindings is dismal.
python-xlib/python3-xlib are simply broken with recent RandR versions.
xpyb, which is the default XCB Python binding, is very out of date and
doesn't have a proper Python 3 support (upstream state is "untested").
xcffib doesn't provide as wide coverage as xpyb, but supports Python3
and can be considered almost usable, but there are still some issues
and it requires Haskell toolchain in order to be built.

Thus drop all the code that interacts with Xlib.

Instead, retrieve the IPC socket path directly from i3.

Call i3 with the `--get-socketpath' command-line option, which is
available since v4.1 release, to retrieve the i3 IPC socket path.