### PR TITLE
Remove newlines from socket path

### DIFF
--- a/i3ipc.py
+++ b/i3ipc.py
@@ -176,7 +176,7 @@ class Connection(object):
             try:
                 socket_path = subprocess.check_output(
                     ['i3', '--get-socketpath'],
-                    close_fds=True, universal_newlines=True)
+                    close_fds=True, universal_newlines=True).strip()
             except:
                 raise Exception('Failed to retrieve the i3 IPC socket path')
 


### PR DESCRIPTION
Hey,

I am not sure, if this is the correct way to deal with this, but for me i3ipc.Connection() gave me the following error:
```
In [5]: i3 = i3ipc.Connection()
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-5-b86818f0fd4c> in <module>()
----> 1 i3 = i3ipc.Connection()

/home/hendrik/dev/evasive-window/i3ipc.py in __init__(self, socket_path)
    187         print(self.socket_path)
    188         self.cmd_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
--> 189         self.cmd_socket.connect(self.socket_path.rstrip())
    190 
    191     def _pack(self, msg_type, payload):

FileNotFoundError: [Errno 2] No such file or directory
```
It seems like there is a newline at the end of the string returned by the subprocess command.
With this change this does not happen.