### PR TITLE
Add window_rect and deco_rect props if available

### DIFF
--- a/i3ipc.py
+++ b/i3ipc.py
@@ -447,6 +447,10 @@ class Con(object):
                 self.window_role = data['window_properties']['window_role']
 
         self.rect = Rect(data['rect'])
+        if 'window_rect' in data:
+            self.window_rect = Rect(data['window_rect'])
+        if 'deco_rect' in data:
+            self.deco_rect = Rect(data['deco_rect'])
 
     def root(self):
         if not self.parent:


### PR DESCRIPTION
I needed deco_rect for a script and saw that it was not yet implemented in i3ipc.py (older versions of i3 don't have the properties - at least deco_rect - so I enclosed it in if blocks).