### PR TITLE
Explicitly set encoding of readme in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup
 from os import path
+from io import open
 
 readme_path = path.join(path.abspath(path.dirname(__file__)), 'README.rst')
-long_description = open(readme_path).read()
+long_description = open(readme_path, encoding='utf-8').read()
 
 install_requires = ['enum-compat']
 


### PR DESCRIPTION
I want to package i3ipc-python for Fedora, but it fails to build within rpmbuild, because it sets LANG=C and setup.py fails to read the readme file. This should fix it.