### PR TITLE
bugfix: fix ipc-shutdown emission + update example

### DIFF
--- a/examples/command-on-exit.py
+++ b/examples/command-on-exit.py
@@ -15,6 +15,6 @@ def on_shutdown(i3):
 
 i3 = i3ipc.Connection()
 
-i3.on('ipc-shutdown', on_shutdown)
+i3.on('ipc_shutdown', on_shutdown)
 
 i3.main()

--- a/i3ipc.py
+++ b/i3ipc.py
@@ -349,7 +349,7 @@ class Connection(object):
 
             if len(data) == 0:
                 # EOF
-                self._pubsub.emit('ipc-shutdown', None)
+                self._pubsub.emit('ipc_shutdown', None)
                 break
 
             data = json.loads(data)


### PR DESCRIPTION
really fix #42: emit 'ipc_shutdown' instead of 'ipc-shutdown'

also update command-on-exit example