### PR TITLE
fixed setup.py and package

### DIFF
--- a/i3ipc/__init__.py
+++ b/i3ipc/__init__.py
@@ -1,0 +1,1 @@
+from .i3ipc import *

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     keywords='i3 i3wm extensions add-ons',
-    py_modules=['i3ipc'],
+    packages=['i3ipc'],
     install_requires=install_requires,
 )


### PR DESCRIPTION
i3ipc [is a package now](0e42da86b6918c8f7c1df70bcad1c630007d4890), so setup.py requires using packages instead of
py_modules.
Added from .i3ipc import * in the package's __init__.py to keep
backwards compatibility and not require an import like `from i3ipc
import i3ipc`.