### PR TITLE
Robustness towards UTF-8 decoding errors

### DIFF
--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -206,7 +206,8 @@ class Connection(object):
         msg_magic, msg_length, msg_type = self._unpack_header(data)
         msg_size = self._struct_header_size + msg_length
         # XXX: Message shouldn't be any longer than the data
-        return data[self._struct_header_size:msg_size].decode('utf-8')
+        payload = data[self._struct_header_size:msg_size]
+        return payload.decode('utf-8', 'replace')
 
     def _unpack_header(self, data):
         """


### PR DESCRIPTION
The default mode 'strict' raises a UnicodeDecodeError on invalid UTF-8 data and crashes the main loop.
Background:
I've that that happen with unicode characters in mpv window titles. Since I use i3ipc for an i3bar status script the crashed main loop (which I run in a daemon thread, thus no crash of the script. the following is speculation:) causes the connection buffer to fill up and i3 to go into an infinite loop/locking up.