### PR TITLE
Fix unicode support in Python 2

### DIFF
--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -348,9 +348,9 @@ class Connection(object):
         Packs the given message type and payload. Turns the resulting
         message into a byte string.
         """
-        pb = payload.encode()
+        pb = payload.encode('utf-8')
         s = struct.pack('=II', len(pb), msg_type.value)
-        return self.MAGIC.encode() + s + pb
+        return self.MAGIC.encode('utf-8') + s + pb
 
     def _unpack(self, data):
         """

--- a/test/ipctest.py
+++ b/test/ipctest.py
@@ -1,4 +1,8 @@
-from subprocess import Popen, run
+from subprocess import Popen
+try:
+    from subprocess import run
+except ImportError:
+    from subprocess import call as run
 import pytest
 import time
 import i3ipc
@@ -33,7 +37,7 @@ class IpcTest:
     def main(self):
         """Start the main thread and wait for events with a timeout"""
 
-        def timeout_function(quit_cv: Condition):
+        def timeout_function(Condition):
             with quit_cv:
                 quit_cv.wait(3)
                 self.i3.main_quit()


### PR DESCRIPTION
In Python 2 default encoding for unicode.encode() is 'ascii'. This PR fixes unicode encoding issue. It also fixes test runner and tests for Python 2.

Reproducing a bug:
```
>>> import i3ipc
>>> i3 = i3ipc.Connection()
>>> i3.command(u'rename workspace 1 to 1:🌐')
...
UnicodeEncodeError: 'ascii' codec can't encode character u'\U0001f310' in position 24: ordinal not in range(128)
```