### PR TITLE
Set floating attribute on Con class

### DIFF
--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -740,6 +740,11 @@ class Con(object):
 
         :returns: :bool:`True` or :bool:`False`.
 
+    .. attribute:: floating
+
+        Whether the container is floating or not. Possible values are
+        "auto_on", "auto_off", "user_on" and "user_off"
+
 
     ..
         command <-- method
@@ -754,6 +759,7 @@ class Con(object):
         find_fullscreen
         find_marked
         find_named
+        floating
         floating_nodes
         fullscreen_mode
         leaves

--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -797,6 +797,10 @@ class Con(object):
             if 'mark' in data and data['mark']:
                 self.marks.append(data['mark'])
 
+        # Possible values 'user_off', 'user_on', 'auto_off', 'auto_on'
+        if data['floating']:
+            self.floating = data['floating']
+
         # XXX this is for compatability with 4.8
         if isinstance(self.type, int):
             if self.type == 0:


### PR DESCRIPTION
Set the floating attribute that is sent from i3 inside the Con class so users can differentiate between floating and non-floating windows.