### PR TITLE
Add focus attribute.

### DIFF
--- a/examples/focused-windows.py
+++ b/examples/focused-windows.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+import i3ipc
+
+i3 = i3ipc.Connection()
+
+def focused_windows():
+  tree = i3.get_tree()
+
+  workspaces = tree.workspaces()
+  for workspace in workspaces:
+    container = workspace
+
+    while container:
+      if not hasattr(container, 'focus') \
+          or not container.focus:
+        break
+
+      container_id = container.focus[0]
+      container = container.find_by_id(container_id)
+
+    if container:
+      coname = container.name
+      wsname = workspace.name
+
+      print('WS', wsname +':', coname)
+
+
+if __name__ == '__main__':
+  parser = ArgumentParser(description = 'Print the names of the focused window of each workspace.')
+  parser.parse_args()
+
+  focused_windows()

--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -728,6 +728,11 @@ class Con(object):
 
         The X11 window ID of the client window.
 
+    .. attribute:: focus
+
+        A list of container ids describing the focus situation within the current
+        container. The first element refers to the container with (in)active focus.
+
     .. attribute:: focused
 
         Whether or not the current container is focused. There is only
@@ -798,7 +803,7 @@ class Con(object):
         self.parent = parent
 
         # set simple properties
-        ipc_properties = ['border', 'current_border_width', 'focused',
+        ipc_properties = ['border', 'current_border_width', 'focus', 'focused',
                           'fullscreen_mode', 'id', 'layout', 'marks', 'name',
                           'orientation', 'percent', 'type', 'urgent', 'window',
                           'num', 'scratchpad_state']


### PR DESCRIPTION
i3 provides information about the focus inside a container as a
list of its children's id, where the first element refers to the
childern with (in)active focus. This information is now available
as focus attribute.