### PR TITLE
add example: focus on vim session

### DIFF
--- a/examples/run_vim_session.py
+++ b/examples/run_vim_session.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import re
+import sys
+
+import psutil
+import i3ipc
+
+def get_window_id_by_pid(pid):
+    with open('/proc/{}/environ'.format(pid), 'r') as f:
+        pid_env = f.read()
+    match = re.search(r'WINDOWID=(\d+)', pid_env)
+    wid = int(match.group(1))
+    return wid
+
+def get_session_pid(session_name):
+    for process in psutil.process_iter():
+        if '--servername {}'.format(session_name.lower()) in ' '.join(process.cmdline()).lower():
+            yield process.pid
+
+def get_vim_window_id(session_name):
+    while True:
+        try:
+            pid = next(get_session_pid(session_name))
+        except StopIteration:
+            break
+        if pid is None:
+            continue
+        else:
+            break
+    return get_window_id_by_pid(pid)
+
+
+def main():
+    for line in sys.stdin:
+        vim_window_id = get_vim_window_id(line.strip('\n'))
+        break
+    if vim_window_id is not None:
+        con = i3ipc.Connection()
+        con.command('[id=%s] focus' % vim_window_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I use tpope's vim-obsession plugin to manage different projects in vim. So I made this little script to focus on a window containg the particular vim instance.