### PR TITLE
Fix: timer is always None

### DIFF
--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -639,7 +639,8 @@ class Connection(object):
             timer = None
 
             if timeout:
-                timer = Timer(timeout, self.main_quit).start()
+                timer = Timer(timeout, self.main_quit)
+                timer.start()
 
             while not self.event_socket_poll():
                 pass


### PR DESCRIPTION
`Timer.start()` returns None. `timer` was always `None` and never got cancelled.