### PR TITLE
travis: use development i3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: xenial
 python:
     - "3.5"
 before_install:
+    - /usr/lib/apt/apt-helper download-file http://debian.sur5r.net/i3/pool/main/s/sur5r-keyring/sur5r-keyring_2018.01.30_all.deb keyring.deb SHA256:baa43dbbd7232ea2b5444cae238d53bebb9d34601cc000e82f11111b1889078a
+    - sudo dpkg -i ./keyring.deb
+    - echo "deb http://debian.sur5r.net/i3/ $(grep '^DISTRIB_CODENAME=' /etc/lsb-release | cut -f2 -d=) universe" | sudo tee /etc/apt/sources.list.d/sur5r-i3.list > /dev/null
     - sudo apt-get update -qq
     - sudo apt-get install xvfb i3
     - sudo pip install pytest


### PR DESCRIPTION
Trying to follow [these instructions](https://i3wm.org/docs/repositories.html) to get the latest development i3 to run for the tests on travis.