### PR TITLE
added floating-mode example script

### DIFF
--- a/examples/floating-mode.py
+++ b/examples/floating-mode.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# budRich@budlabs - 2019
+#
+# this will make all new windows floating
+# due to the way i3 handles for_window rules
+# setting a "global rule" to make all new
+# windows floating, may have undesired side effects.
+#
+# https://github.com/i3/i3/issues/3628
+# https://github.com/i3/i3/pull/3188
+# https://old.reddit.com/r/i3wm/comments/85ctji/when_windows_are_floating_by_default_how_do_i/
+
+from i3ipc import Connection
+i3 = Connection()
+
+
+def set_floating(i3, event):
+    event.container.command('floating enable')
+
+
+i3.on('window::new', set_floating)
+i3.main()


### PR DESCRIPTION
this is the solution to a thing that have bugged me in i3 for a long time.
I have a global rule set to make all new windows floating:  
`for_window [class="^.*"] floating enable`  
But i3 triggers this rule after the config is reloaded and the **title** of a window changes (which happens when you change tab in the browser or file in the editor fi). I thought i add it as an example script. 

Thanks for a great tool!

https://github.com/i3/i3/issues/3628  
https://old.reddit.com/r/i3wm/comments/85ctji/when_windows_are_floating_by_default_how_do_i/  

(*i am not the reddit user. *)