### PR TITLE
fix saved values for on("binding::x") event callback

### DIFF
--- a/examples/adapt_window_transparency.py
+++ b/examples/adapt_window_transparency.py
@@ -1,0 +1,50 @@
+import i3ipc
+
+ipc = i3ipc.Connection()
+
+w_to_opac = {w.id: 1 for w in ipc.get_tree()}
+
+
+def update_call(ipc, __):
+    global w_to_opac
+    w_to_opac = {w.id: 1 for w in ipc.get_tree()}
+    for w in ipc.get_tree():
+        if w.id not in w_to_opac:
+            w_to_opac[w.id] = 1
+
+
+def on_binding_call(ipc, binding_event):
+
+    sequence = '+'.join(binding_event.binding.mods +
+                        binding_event.binding.symbols)
+
+    def minus_func(x):
+        if w_to_opac[x.id] > 0:
+            w_to_opac[x.id] -= .1
+        return str(w_to_opac[x.id])
+
+    def plus_func(x):
+        if w_to_opac[x.id] < 1:
+            w_to_opac[x.id] += .1
+        return str(w_to_opac[x.id])
+
+    def equal_func(x):
+        w_to_opac[x.id] = 1
+        return str(w_to_opac[x.id])
+
+    lamb = None
+    if sequence == 'Mod4+minus':
+        lamb = minus_func
+    if sequence == 'Mod4+plus':
+        lamb = plus_func
+    if sequence == 'Mod4+equal':
+        lamb = equal_func
+
+    for window in ipc.get_tree():
+        if window.focused and lamb:
+            window.command('opacity '+lamb(window))
+
+
+ipc.on("binding::run", on_binding_call)
+ipc.on("window::new", update_call)
+ipc.main()

--- a/i3ipc/i3ipc.py
+++ b/i3ipc/i3ipc.py
@@ -253,9 +253,9 @@ class BarconfigUpdateEvent(object):
 class BindingInfo(object):
     def __init__(self, data):
         self.command = data['command']
-        self.mods = data['mods']
+        self.mods = data['event_state_mask']
         self.input_code = data['input_code']
-        self.symbol = data['symbol']
+        self.symbols = data['symbols']
         self.input_type = data['input_type']
 
 


### PR DESCRIPTION
current code was trying to access missing value in dict ("mods"), and
stored values where not sufficient to actually act on specific bindings

added example to change transparency of focused window using bindings